### PR TITLE
Fix #118, improved monitor.

### DIFF
--- a/srttools/scan.py
+++ b/srttools/scan.py
@@ -74,17 +74,17 @@ def product_path_from_file_name(fname, workdir='.', productdir=None):
     >>> os.path.abspath(path) == os.path.abspath(os.path.join('be', 'bla'))
     True
     """
-    if productdir is None:
-        productdir = '.'
     filedir, fn = os.path.split(fname)
     if filedir == '':
-        filedir = '.'
+        filedir = os.path.abspath(os.curdir)
+    if productdir is None:
+        rootdir = filedir
+    else:
+        base = os.path.commonprefix([filedir, workdir])
+        relpath = os.path.relpath(filedir, base)
+        rootdir = os.path.join(productdir, relpath)
 
-    base = os.path.commonprefix([filedir, workdir])
-    relpath = os.path.relpath(filedir, base)
-
-    rootdir = os.path.join(productdir, relpath)
-    return rootdir, fn
+    return os.path.normpath(rootdir), fn
 
 
 def angular_distance(angle0, angle1):

--- a/srttools/tests/test_monitor.py
+++ b/srttools/tests/test_monitor.py
@@ -53,6 +53,7 @@ class TestMonitor(object):
             os.path.abspath(os.path.join(klass.proddir,
                                          "srt_data_dummy_1.jpg"))
         klass.file_index = 'index.html'
+        klass.dummy_config = 'monitor_config.ini'
 
         if os.path.exists(klass.file_empty):
             os.unlink(klass.file_empty)
@@ -165,6 +166,7 @@ class TestMonitor(object):
             assert os.path.exists(fname)
             os.unlink(fname)
 
+
     @pytest.mark.skipif('not HAS_WATCHDOG')
     def test_delete_old_images(self):
         def process():
@@ -196,3 +198,5 @@ class TestMonitor(object):
     def teardown_class(klass):
         if os.path.exists(klass.file_index):
             os.unlink(klass.file_index)
+        if os.path.exists(klass.dummy_config):
+            os.unlink(klass.dummy_config)


### PR DESCRIPTION
Now the `SDTmonitor` script can monitor multiple directories. The command line behavior is the same as before, but you can specify via CLI multiple directories to be monitored one after the other.

I.e.:
SDTmonitor /data/dir1 /data/dir2 /data/dirN

This avoid launching and handling multiple SDTmonitor processes for different directories, causing less computational overhead on the system.