### PR TITLE
Fix #129, fixed the wrong doctest on `scan.py`.

### DIFF
--- a/srttools/scan.py
+++ b/srttools/scan.py
@@ -68,7 +68,7 @@ def product_path_from_file_name(fname, workdir='.', productdir=None):
     >>> dumdir = os.path.join('bu', 'bla')
     >>> dumfile = os.path.join(dumdir, 'ciao.ciao')
     >>> path, fname = product_path_from_file_name(dumfile, workdir=dumdir, productdir=None)
-    >>> os.path.abspath(path) == curpath
+    >>> os.path.abspath(path) == os.path.abspath(dumdir)
     True
     >>> path, fname = product_path_from_file_name(dumfile, workdir='bu', productdir='be')
     >>> os.path.abspath(path) == os.path.abspath(os.path.join('be', 'bla'))


### PR DESCRIPTION
The test was passing before a change to `scan.product_path_from_file_name` was made. I think that the test was conceptually wrong, since without the fix to the said method, the SDTmonitor was not working properly because the `product_path_from_file_name` method was using relative paths causing some path issues.