### PR TITLE
Fix #135, the SDTmonitor now can provide HTTP access.

### DIFF
--- a/docs/scripts/cli.rst
+++ b/docs/scripts/cli.rst
@@ -268,18 +268,25 @@ SDTmonitor
 
 .. code-block:: none
 
-    usage: SDTmonitor [-h] [-c CONFIG] [--test] directory
+    usage: SDTmonitor [-h] [-c CONFIG] [--test] [--nosave] [-p]
+                      [--http-server-port HTTP_SERVER_PORT]
+                      directories [directories ...]
 
     Run the SRT quicklook in a given directory.
 
     positional arguments:
-      directory             Directory to monitor
+      directories           Directories to monitor
 
     optional arguments:
       -h, --help            show this help message and exit
       -c CONFIG, --config CONFIG
                             Config file
       --test                Only to be used in tests!
+      --nosave              Do not save the hdf5 intermediate files
+      -p, --polling         Use a platform-independent, polling watchdog
+      --http-server-port HTTP_SERVER_PORT
+                            Share the results via HTTP server on given
+                            HTTP_SERVER_PORT
 
 
 SDTopacity

--- a/srttools/monitor.py
+++ b/srttools/monitor.py
@@ -178,7 +178,7 @@ def main_monitor(args=None):
 
     if args.http_server_port:
         http_server = sp.Popen(
-                ['python', '-m', 'http.server', '{}'.format(args.http_server_port)],
+            ['python', '-m', 'http.server', '{}'.format(args.http_server_port)],
             stderr=sp.DEVNULL
         )
 

--- a/srttools/monitor.py
+++ b/srttools/monitor.py
@@ -145,6 +145,11 @@ def main_monitor(args=None):
         action='store_true',
         default=False
     )
+    parser.add_argument(
+        "--http-server-port",
+        help="Share the results via HTTP server on given port",
+        type=int
+    )
     args = parser.parse_args(args)
 
     if not HAS_WATCHDOG:
@@ -170,6 +175,13 @@ def main_monitor(args=None):
         observer.schedule(event_handler, path, recursive=True)
 
     observer.start()
+
+    if args.http_server_port:
+        http_server = sp.Popen(
+                ['python', '-m', 'http.server', '{}'.format(args.http_server_port)],
+            stderr=sp.DEVNULL
+        )
+
     try:
         count = 0
         while count < 10:
@@ -179,6 +191,10 @@ def main_monitor(args=None):
         raise KeyboardInterrupt
     except KeyboardInterrupt:
         pass
+
+    if args.http_server_port:
+        http_server.kill()
+
     observer.stop()
 
 

--- a/srttools/tests/test_monitor.py
+++ b/srttools/tests/test_monitor.py
@@ -194,7 +194,7 @@ class TestMonitor(object):
             os.unlink(fname)
 
     @pytest.mark.skipif('not HAS_WATCHDOG')
-    def test_polling(self):
+    def test_http_server(self):
         def process():
             main_monitor([self.datadir, '--test', '--http-server-port', '10000'])
 

--- a/srttools/tests/test_monitor.py
+++ b/srttools/tests/test_monitor.py
@@ -166,7 +166,6 @@ class TestMonitor(object):
             assert os.path.exists(fname)
             os.unlink(fname)
 
-
     @pytest.mark.skipif('not HAS_WATCHDOG')
     def test_delete_old_images(self):
         def process():
@@ -191,6 +190,26 @@ class TestMonitor(object):
         for fname in files[4:]:
             assert not os.path.exists(fname)
         for fname in files[:4]:
+            assert os.path.exists(fname)
+            os.unlink(fname)
+
+    @pytest.mark.skipif('not HAS_WATCHDOG')
+    def test_polling(self):
+        def process():
+            main_monitor([self.datadir, '--test', '--http-server-port', '10000'])
+
+        w = threading.Thread(name='worker', target=process)
+        w.start()
+        time.sleep(1)
+
+        sp.check_call('cp {} {}'.format(self.file_empty_init,
+                                        self.file_empty).split())
+
+        time.sleep(8)
+        w.join()
+
+        for fname in [self.file_empty_pdf0, self.file_empty_pdf1,
+                      'latest_0.jpg', 'latest_1.jpg']:
             assert os.path.exists(fname)
             os.unlink(fname)
 

--- a/srttools/tests/test_monitor.py
+++ b/srttools/tests/test_monitor.py
@@ -208,9 +208,16 @@ class TestMonitor(object):
 
         time.sleep(7)
 
+        urls = [
+            '',
+            'index.html',
+            'latest_0.jpg',
+            'latest_1.jpg',
+            'latest_0.jpg?%d' % int(time.time())
+        ]
         # Check that the files are provided by the HTTP server
-        for i in range(2):
-            url = 'http://127.0.0.1:10000/latest_{}.jpg'.format(i)
+        for url in urls:
+            url = 'http://127.0.0.1:10000/' + url
             r = urllib.request.urlopen(url)
             assert r.code == 200
 
@@ -262,19 +269,20 @@ class TestMonitor(object):
 
         time.sleep(7)
 
-        # Create a dummy 'forbidden' file.
-        # The file should not be accessible since its name is not 'index.html',
-        # nor 'index.html' and also its name does not match the 'latest_X.EXT'
-        # pattern
-        open('forbidden', 'w').close()
-        url = 'http://127.0.0.1:10000/forbidden'
+        # Create a dummy 'latest_0.txt' file.
+        # The file should not be accessible since its name does not match
+        # 'index.html' nor 'index.html' nor 'latest_X.EXT' pattern, with EXT
+        # equal to the configured file extension, in this case is 'jpg'
+        forbidden_file = 'latest_0.txt'
+        open(forbidden_file, 'w').close()
+        url = 'http://127.0.0.1:10000/' + forbidden_file
         with pytest.raises(urllib.error.HTTPError):
             r = urllib.request.urlopen(url)
 
         w.join()
 
         for fname in [self.file_empty_pdf0, self.file_empty_pdf1,
-                      'latest_0.jpg', 'latest_1.jpg', 'forbidden']:
+                      'latest_0.jpg', 'latest_1.jpg', forbidden_file]:
             assert os.path.exists(fname)
             os.unlink(fname)
 


### PR DESCRIPTION
Using the flag `--http-server-port`, followed by the desired port, the whole directory where the SDTmonitor is launched is shared across the network and can be accessed via browser by typing the name or the IP of the machine on which it's running, followed by the said port. I.e. launching the monitor with the following command `SDTmonitor --http-server-port 8080` starts a HTTP server that can be accessed via bworser on the local machine typing `localhost:8080`, or `<hostname or IP>:8080` if you are on a different machine.