### PR TITLE
Allow the code to be imported in Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
         # may run for a long time
         # Try all python versions with the latest numpy
 
-        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage' PIP_DEPENDENCIES='patsy codecov faulthandler'
+        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage' PIP_DEPENDENCIES='patsy codecov faulthandler future'
         - env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage' SETUP_XVFB=False
         # No matplotlib, with old scipy
         - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy=0.19 pytest pip h5py statsmodels pyyaml numba pyregion' SETUP_CMD='test --coverage'
@@ -61,7 +61,7 @@ matrix:
         - env: PYTHON_VERSION=3.4 SETUP_CMD='test' NUMPY_VERSION=1.11
     allow_failures:
         # Try Astropy development version
-        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage' PIP_DEPENDENCIES='patsy codecov faulthandler'
+        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage' PIP_DEPENDENCIES='patsy codecov faulthandler future'
         - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=development SETUP_CMD='test'
         - env: PYTHON_VERSION=3.4 SETUP_CMD='test' NUMPY_VERSION=1.11
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Introduction
 
 .. warning::
    *Limited* support for python 2.7 will be maintained until December 2018.
-   After, the srttools will only be support Python 3.5 and later.
+   After, the srttools will only support Python 3.5 and later.
 
 The Sardinia Radio Telescope Single Dish Tools (SDT) are a set of Python
 tools designed for the quicklook and analysis of single-dish radio data,
@@ -102,6 +102,11 @@ and install the dependencies (including a few optional but recommended):
 
     $ pip install pyregion
 
+For Python 2 (if you must...), please install `future`:
+
+.. code-block:: console
+
+    $ pip install future
 
 Other Python distributions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,6 +117,12 @@ recommended):
 .. code-block:: console
 
     $ pip install astropy>=3 scipy numpy matplotlib pyyaml h5py statsmodels numba pyregion
+
+For Python 2 (if you must...), please install `future`:
+
+.. code-block:: console
+
+    $ pip install future
 
 Cloning and installation
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/srttools/monitor.py
+++ b/srttools/monitor.py
@@ -18,18 +18,23 @@ import subprocess as sp
 import glob
 from threading import Timer, Thread
 from multiprocessing import Process, Queue, cpu_count
+import warnings
 
 try:
     from queue import Empty
-    HAS_QUEUE = True
 except ImportError:
-    HAS_QUEUE = False
+    from Queue import Empty
+    warnings.warn("Monitoring interface does not work with Python < 3.5",
+                  DeprecationWarning)
 
 try:
     from http.server import HTTPServer, SimpleHTTPRequestHandler, HTTPStatus
-    HAS_HTTP = True
 except ImportError:
-    HAS_HTTP = False
+    from BaseHTTPServer import HTTPServer
+    from SimpleHTTPServer import SimpleHTTPRequestHandler
+    class HTTPStatus:
+        pass
+    HTTPStatus.NOT_FOUND = 404
 
 from srttools.read_config import read_config
 from srttools.scan import product_path_from_file_name

--- a/srttools/monitor.py
+++ b/srttools/monitor.py
@@ -14,13 +14,22 @@ try:
 except ImportError:
     PatternMatchingEventHandler = object
     HAS_WATCHDOG = False
-import warnings
 import subprocess as sp
 import glob
 from threading import Timer, Thread
-from multiprocessing import Process, Queue
-from queue import Empty
-from http.server import HTTPServer, SimpleHTTPRequestHandler, HTTPStatus
+from multiprocessing import Process, Queue, cpu_count
+
+try:
+    from queue import Empty
+    HAS_QUEUE = True
+except ImportError:
+    HAS_QUEUE = False
+
+try:
+    from http.server import HTTPServer, SimpleHTTPRequestHandler, HTTPStatus
+    HAS_HTTP = True
+except ImportError:
+    HAS_HTTP = False
 
 from srttools.read_config import read_config
 from srttools.scan import product_path_from_file_name
@@ -33,8 +42,8 @@ except ImportError:
 
 
 MAX_PROC = 1
-if os.cpu_count():
-    MAX_PROC = int(min(os.cpu_count() / 2, 5))
+if cpu_count():
+    MAX_PROC = int(min(cpu_count() / 2, 5))
 
 
 class MyEventHandler(PatternMatchingEventHandler):


### PR DESCRIPTION
@giuseppe-carboni please review. 
I'm putting `queue` and `http` in a `try..except` block, and substituting `os.cpu_count` with `multiprocessing.cpu_count`.  This allows the code to be imported and tests to be run (and maybe fail, it's acceptable) in Python 2
Resolve #148 