### PR TITLE
Fix #153, fixed wrong backend name issue.

### DIFF
--- a/srttools/io.py
+++ b/srttools/io.py
@@ -433,10 +433,10 @@ def _read_data_fitszilla(lchdulist):
         backend = lchdulist[0].header['BACKEND NAME']
     except Exception:
         if 'stokes' in types:
-            if nbin_per_chan > 2048:
-                backend = 'SARDARA'
-            else:
+            if nbin_per_chan == 2048:
                 backend = 'XARCOS'
+            else:
+                backend = 'SARDARA'
         elif 'spectra' in types:
             backend = 'SARDARA'
         else:


### PR DESCRIPTION
This is a temporary fix. Since Sardara backend now can support only 1024
or 16000+ bins per channel, this fix is valid. In the future it will
support also other configurations. When the 2048 bins per channel
configuration will be implemented we will have to find another way to
identify SARDARA or XARCOS backend.