### PR TITLE
Fix #150, suppressed some warnings in monitor logfile.

### DIFF
--- a/srttools/monitor.py
+++ b/srttools/monitor.py
@@ -7,6 +7,7 @@ import shutil
 import re
 import sys
 import signal
+import warnings
 try:
     from watchdog.observers import Observer
     from watchdog.observers.polling import PollingObserver
@@ -110,7 +111,9 @@ class MyEventHandler(PatternMatchingEventHandler):
                 pp_args.append('--nosave')
             pp_args.append(infile)
             try:
-                main_preprocess(pp_args)
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore')
+                    main_preprocess(pp_args)
             except:
                 continue
 


### PR DESCRIPTION
I think that preprocessing warnings related to a specific fits file should not be reported in the monitor logfile. I believe this file should be used to log the actual behavior of the monitor itself. This commit in fact suppress all the warnings that may come out from the image processing method.