### PR TITLE
Fix #169, slightly changed monitor worker processes spawning behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,4 +91,4 @@ after_success:
 #    # If coveralls.io is set up for this package, uncomment the line
 #    # below and replace "packagename" with the name of your package.
 #    # The coveragerc file may be customized as needed for your package.
-   - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='srttools/tests/coveragerc'; codecov; fi
+   - if [[ $SETUP_CMD == 'test --coverage' ]]; then coverage combine --append; coveralls --rcfile='srttools/tests/coveragerc'; codecov; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,14 @@ matrix:
         # may run for a long time
         # Try all python versions with the latest numpy
 
-        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage && coverage combine' PIP_DEPENDENCIES='patsy codecov faulthandler future'
-        - env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage && coverage combine' SETUP_XVFB=False
+        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage; coverage combine' PIP_DEPENDENCIES='patsy codecov faulthandler future'
+        - env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage; coverage combine' SETUP_XVFB=False
         # No matplotlib, with old scipy
-        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy=0.19 pytest pip h5py statsmodels pyyaml numba pyregion' SETUP_CMD='test --coverage && coverage combine'
+        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy=0.19 pytest pip h5py statsmodels pyyaml numba pyregion' SETUP_CMD='test --coverage; coverage combine'
         # No NUMBA, pyregion
-        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy matplotlib pytest pip h5py statsmodels pyyaml' SETUP_CMD='test --coverage && coverage combine'
+        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy matplotlib pytest pip h5py statsmodels pyyaml' SETUP_CMD='test --coverage; coverage combine'
         # No statsmodels
-        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy matplotlib pytest pip h5py pyyaml numba pyregion' PIP_DEPENDENCIES='patsy codecov mahotas watchdog pillow' SETUP_CMD='test --coverage && coverage combine'
+        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy matplotlib pytest pip h5py pyyaml numba pyregion' PIP_DEPENDENCIES='patsy codecov mahotas watchdog pillow' SETUP_CMD='test --coverage; coverage combine'
         # Documentation
         - env: PYTHON_VERSION=3.6 SETUP_CMD='build_docs -w'
 
@@ -61,7 +61,7 @@ matrix:
         - env: PYTHON_VERSION=3.4 SETUP_CMD='test' NUMPY_VERSION=1.11
     allow_failures:
         # Try Astropy development version
-        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage && coverage combine' PIP_DEPENDENCIES='patsy codecov faulthandler future'
+        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage; coverage combine' PIP_DEPENDENCIES='patsy codecov faulthandler future'
         - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=development SETUP_CMD='test'
         - env: PYTHON_VERSION=3.4 SETUP_CMD='test' NUMPY_VERSION=1.11
 
@@ -91,4 +91,4 @@ after_success:
 #    # If coveralls.io is set up for this package, uncomment the line
 #    # below and replace "packagename" with the name of your package.
 #    # The coveragerc file may be customized as needed for your package.
-   - if [[ $SETUP_CMD == 'test --coverage && coverage combine' ]]; then coveralls --rcfile='srttools/tests/coveragerc'; codecov; fi
+   - if [[ $SETUP_CMD == 'test --coverage; coverage combine' ]]; then coveralls --rcfile='srttools/tests/coveragerc'; codecov; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ before_script:
 script:
     - $MAIN_CMD $SETUP_CMD
 after_script:
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coverage combine fi
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coverage combine; fi
 
 after_success:
 #    # If coveralls.io is set up for this package, uncomment the line

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,8 +85,8 @@ before_script:
 
 script:
     - $MAIN_CMD $SETUP_CMD
+    - if [ "$SETUP_CMD" = "test --coverage" ]; then coverage combine; fi
 after_script:
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coverage combine; fi
 
 after_success:
 #    # If coveralls.io is set up for this package, uncomment the line

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,14 @@ matrix:
         # may run for a long time
         # Try all python versions with the latest numpy
 
-        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage' PIP_DEPENDENCIES='patsy codecov faulthandler future'
-        - env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage' SETUP_XVFB=False
+        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage && coverage combine' PIP_DEPENDENCIES='patsy codecov faulthandler future'
+        - env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage && coverage combine' SETUP_XVFB=False
         # No matplotlib, with old scipy
-        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy=0.19 pytest pip h5py statsmodels pyyaml numba pyregion' SETUP_CMD='test --coverage'
+        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy=0.19 pytest pip h5py statsmodels pyyaml numba pyregion' SETUP_CMD='test --coverage && coverage combine'
         # No NUMBA, pyregion
-        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy matplotlib pytest pip h5py statsmodels pyyaml' SETUP_CMD='test --coverage'
+        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy matplotlib pytest pip h5py statsmodels pyyaml' SETUP_CMD='test --coverage && coverage combine'
         # No statsmodels
-        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy matplotlib pytest pip h5py pyyaml numba pyregion' PIP_DEPENDENCIES='patsy codecov mahotas watchdog pillow' SETUP_CMD='test --coverage'
+        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy matplotlib pytest pip h5py pyyaml numba pyregion' PIP_DEPENDENCIES='patsy codecov mahotas watchdog pillow' SETUP_CMD='test --coverage && coverage combine'
         # Documentation
         - env: PYTHON_VERSION=3.6 SETUP_CMD='build_docs -w'
 
@@ -61,7 +61,7 @@ matrix:
         - env: PYTHON_VERSION=3.4 SETUP_CMD='test' NUMPY_VERSION=1.11
     allow_failures:
         # Try Astropy development version
-        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage' PIP_DEPENDENCIES='patsy codecov faulthandler future'
+        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage && coverage combine' PIP_DEPENDENCIES='patsy codecov faulthandler future'
         - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=development SETUP_CMD='test'
         - env: PYTHON_VERSION=3.4 SETUP_CMD='test' NUMPY_VERSION=1.11
 
@@ -91,4 +91,4 @@ after_success:
 #    # If coveralls.io is set up for this package, uncomment the line
 #    # below and replace "packagename" with the name of your package.
 #    # The coveragerc file may be customized as needed for your package.
-   - if [[ $SETUP_CMD == 'test --coverage' ]]; then coverage combine --append; coveralls --rcfile='srttools/tests/coveragerc'; codecov; fi
+   - if [[ $SETUP_CMD == 'test --coverage && coverage combine' ]]; then coveralls --rcfile='srttools/tests/coveragerc'; codecov; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,14 @@ matrix:
         # may run for a long time
         # Try all python versions with the latest numpy
 
-        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage; coverage combine' PIP_DEPENDENCIES='patsy codecov faulthandler future'
-        - env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage; coverage combine' SETUP_XVFB=False
+        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage' PIP_DEPENDENCIES='patsy codecov faulthandler future'
+        - env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage' SETUP_XVFB=False
         # No matplotlib, with old scipy
-        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy=0.19 pytest pip h5py statsmodels pyyaml numba pyregion' SETUP_CMD='test --coverage; coverage combine'
+        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy=0.19 pytest pip h5py statsmodels pyyaml numba pyregion' SETUP_CMD='test --coverage'
         # No NUMBA, pyregion
-        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy matplotlib pytest pip h5py statsmodels pyyaml' SETUP_CMD='test --coverage; coverage combine'
+        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy matplotlib pytest pip h5py statsmodels pyyaml' SETUP_CMD='test --coverage'
         # No statsmodels
-        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy matplotlib pytest pip h5py pyyaml numba pyregion' PIP_DEPENDENCIES='patsy codecov mahotas watchdog pillow' SETUP_CMD='test --coverage; coverage combine'
+        - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='scipy matplotlib pytest pip h5py pyyaml numba pyregion' PIP_DEPENDENCIES='patsy codecov mahotas watchdog pillow' SETUP_CMD='test --coverage'
         # Documentation
         - env: PYTHON_VERSION=3.6 SETUP_CMD='build_docs -w'
 
@@ -61,7 +61,7 @@ matrix:
         - env: PYTHON_VERSION=3.4 SETUP_CMD='test' NUMPY_VERSION=1.11
     allow_failures:
         # Try Astropy development version
-        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage; coverage combine' PIP_DEPENDENCIES='patsy codecov faulthandler future'
+        - env: PYTHON_VERSION=2.7 SETUP_CMD='test --coverage' PIP_DEPENDENCIES='patsy codecov faulthandler future'
         - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=development SETUP_CMD='test'
         - env: PYTHON_VERSION=3.4 SETUP_CMD='test' NUMPY_VERSION=1.11
 
@@ -86,9 +86,10 @@ before_script:
 script:
     - $MAIN_CMD $SETUP_CMD
 after_script:
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coverage combine fi
 
 after_success:
 #    # If coveralls.io is set up for this package, uncomment the line
 #    # below and replace "packagename" with the name of your package.
 #    # The coveragerc file may be customized as needed for your package.
-   - if [[ $SETUP_CMD == 'test --coverage; coverage combine' ]]; then coveralls --rcfile='srttools/tests/coveragerc'; codecov; fi
+   - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='srttools/tests/coveragerc'; codecov; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,6 @@ before_script:
 
 script:
     - $MAIN_CMD $SETUP_CMD
-    - if [ "$SETUP_CMD" = "test --coverage" ]; then coverage combine; fi
 after_script:
 
 after_success:

--- a/docs/scripts/cli.rst
+++ b/docs/scripts/cli.rst
@@ -292,7 +292,7 @@ SDTmonitor
                             HTTP_SERVER_PORT
       -v, --verbosity       Set the verbosity level
       -w WORKERS, --workers WORKERS
-                            The number of worker processes to spawn
+                            The maximum number of worker processes to spawn
 
 
 SDTopacity
@@ -338,7 +338,7 @@ SDTpreprocess
 .. code-block:: none
 
     usage: SDTpreprocess [-h] [-c CONFIG] [--sub] [--interactive] [--nofilt]
-                         [--debug] [--nosave] [--splat SPLAT]
+                         [--debug] [--plot] [--nosave] [--splat SPLAT]
                          [-e EXCLUDE [EXCLUDE ...]]
                          [files [files ...]]
 
@@ -355,7 +355,8 @@ SDTpreprocess
       --sub                 Subtract the baseline from single scans
       --interactive         Open the interactive display for each scan
       --nofilt              Do not filter noisy channels
-      --debug               Plot stuff and be verbose
+      --debug               Be verbose
+      --plot                Plot stuff
       --nosave              Do not save the hdf5 intermediate files whenloading
                             subscans.
       --splat SPLAT         Spectral scans will be scrunched into a single channel

--- a/srttools/imager.py
+++ b/srttools/imager.py
@@ -1458,7 +1458,10 @@ def main_preprocess(args=None):
                         help='Do not filter noisy channels')
 
     parser.add_argument("--debug", action='store_true', default=False,
-                        help='Plot stuff and be verbose')
+                        help='Be verbose')
+
+    parser.add_argument("--plot", action='store_true', default=False,
+                        help='Plot stuff')
 
     parser.add_argument("--nosave", action='store_true',
                         default=False,
@@ -1493,7 +1496,7 @@ def main_preprocess(args=None):
             try:
                 Scan(f, freqsplat=args.splat, nosub=not args.sub,
                      norefilt=False, debug=args.debug,
-                     interactive=args.interactive,
+                     plot=args.plot, interactive=args.interactive,
                      avoid_regions=excluded_radec,
                      config_file=args.config,
                      nosave=args.nosave)
@@ -1505,6 +1508,6 @@ def main_preprocess(args=None):
             raise ValueError("Please specify the config file!")
         ScanSet(args.config, norefilt=False, freqsplat=args.splat,
                 nosub=not args.sub, nofilt=args.nofilt, debug=args.debug,
-                interactive=args.interactive, avoid_regions=excluded_radec,
-                nosave=args.nosave)
+                plot=args.plot, interactive=args.interactive,
+                avoid_regions=excluded_radec, nosave=args.nosave)
     return 0

--- a/srttools/monitor.py
+++ b/srttools/monitor.py
@@ -109,10 +109,13 @@ class MyEventHandler(PatternMatchingEventHandler):
             p.daemon = True
             p.start()
             p.join()
-            if p.exitcode not in [0, 1]:
-                log.info('Process {} exited with unexpected code {}'.format(
-                    p.pid, p.exitcode
-                ))
+            try:
+                if p.exitcode not in [0, 1]:
+                    log.info('Process {} exited with unexpected code {}'.format(
+                        p.pid, p.exitcode
+                    ))
+            except AttributeError:
+                pass
             self.processing_queue.remove(infile)
 
     @staticmethod
@@ -301,6 +304,8 @@ def main_monitor(args=None):
 
     if not args.test:
         del log.handlers[:]  # Needed to prevent duplicate logging entries
+    else:
+        Process = threading.Thread
 
     from astropy.logger import logging
     logging.basicConfig(

--- a/srttools/monitor.py
+++ b/srttools/monitor.py
@@ -376,7 +376,7 @@ def create_dummy_config():
     [local]
     [analysis]
     [debugging]
-    debug_file_format : jpg
+    debug_file_format : png
     """
     with open('monitor_config.ini', 'w') as fobj:
         print(config_str, file=fobj)

--- a/srttools/monitor.py
+++ b/srttools/monitor.py
@@ -44,7 +44,6 @@ except ImportError:
 MAX_FEEDS = 7
 
 class MyEventHandler(PatternMatchingEventHandler):
-    #ignore_patterns = ['*/tempfits/*']
     patterns = \
         ["*/*.fits"] + ["*/*.fits{}".format(x) for x in range(MAX_FEEDS)]
 

--- a/srttools/monitor.py
+++ b/srttools/monitor.py
@@ -19,16 +19,9 @@ except ImportError:
 import warnings
 import glob
 import threading
-from multiprocessing import Process, Queue, Manager, Lock, cpu_count
+from multiprocessing import Process, Lock
 
 from astropy import log
-
-try:
-    from queue import Empty
-except ImportError:
-    from Queue import Empty
-    warnings.warn("Monitoring interface does not work with Python < 3.5",
-                  DeprecationWarning)
 
 try:
     from http.server import HTTPServer, SimpleHTTPRequestHandler, HTTPStatus
@@ -51,6 +44,7 @@ except ImportError:
 MAX_FEEDS = 7
 
 class MyEventHandler(PatternMatchingEventHandler):
+    #ignore_patterns = ['*/tempfits/*']
     patterns = \
         ["*/*.fits"] + ["*/*.fits{}".format(x) for x in range(MAX_FEEDS)]
 
@@ -58,44 +52,20 @@ class MyEventHandler(PatternMatchingEventHandler):
         super().__init__()
         self.conf = getattr(sys.modules[__name__], 'conf')
         create_index_file(self.conf['debug_file_format'])
+        
+        self.max_proc = n_proc
+
         self.timers = {}
-        self.filequeue = Queue()
-        self.manager = Manager()
         self.lock = Lock()
-        self.processing_queue = self.manager.list()
-        proc_args = (
-            self.filequeue,
-            self.conf,
-            nosave,
-            verbosity,
-            self.lock,
-            self.processing_queue
-        )
+        self.processing_queue = []
+        self.waiting_queue = []
+
+        self.nosave = nosave
+        self.verbosity = verbosity
 
         self.on_modified = self._start_timer
         self.on_created = self._start_timer
         self.on_moved = self._start_timer
-
-        if n_proc == 1:
-            p_type = threading.Thread
-        else:
-            p_type = Process
-        self.processes = []
-        for _ in range(n_proc):
-            p = p_type(target=self._dequeue, args=proc_args)
-            p.daemon = True
-            p.start()
-            if isinstance(p, Process):
-                log.info('Starting worker process, pid {}'.format(p.pid))
-            self.processes.append(p)
-
-    def __del__(self):
-        for p in self.processes:
-            try:
-                p.terminate()
-                log.info('Stopping worker process, pid {}'.format(p.pid))
-            except AttributeError:
-                pass
 
     def _start_timer(self, event):
         infile = ''
@@ -113,27 +83,45 @@ class MyEventHandler(PatternMatchingEventHandler):
             self.timers[infile].cancel()
 
         self.timers[infile] = threading.Timer(
-            0.05,
+            1,
             self._enqueue,
             args=[infile]
         )
+        self.timers[infile].daemon = True
         self.timers[infile].start()
 
     def _enqueue(self, infile):
         if self.timers.get(infile):
             del self.timers[infile]
-        if infile not in self.processing_queue:
-            self.filequeue.put(infile)
+        if infile not in self.waiting_queue:
+            self.waiting_queue.append(infile)
+            while len(self.processing_queue) == self.max_proc:
+                time.sleep(0.05)
+            self.waiting_queue.remove(infile)
             self.processing_queue.append(infile)
+            proc_args = (
+                infile,
+                self.conf,
+                self.nosave,
+                self.verbosity,
+                self.lock
+            )
+            p = Process(target=self.process, args=proc_args)
+            p.daemon = True
+            p.start()
+            p.join()
+            if p.exitcode not in [0, 1]:
+                log.info('Process {} exited with unexpected code {}'.format(
+                    p.pid, p.exitcode
+                ))
+            self.processing_queue.remove(infile)
 
     @staticmethod
-    def _dequeue(filequeue, conf, nosave, verbosity, lock, processing_queue):
-        ext = conf['debug_file_format']
-        while True:
-            try:
-                infile = filequeue.get()
-            except (KeyboardInterrupt, EOFError):
-                return
+    def process(infile, conf, nosave, verbosity, lock):
+        try:
+            pid = os.getpid()
+            log.info('Loading file {}, pid {}'.format(infile, pid))
+            ext = conf['debug_file_format']
 
             productdir, fname = product_path_from_file_name(
                 infile,
@@ -142,7 +130,7 @@ class MyEventHandler(PatternMatchingEventHandler):
             )
             root = os.path.join(productdir, fname.rsplit('.fits')[0])
 
-            pp_args = ['--debug', '-c', conf['configuration_file_name']]
+            pp_args = ['--plot', '-c', conf['configuration_file_name']]
             if nosave:
                 pp_args.append('--nosave')
             pp_args.append(infile)
@@ -154,14 +142,15 @@ class MyEventHandler(PatternMatchingEventHandler):
                         warnings.simplefilter('ignore')
                     if main_preprocess(pp_args):
                         skip = True
+            except KeyboardInterrupt:
+                raise KeyboardInterrupt
             except:
                 log.exception(sys.exc_info()[1])
                 skip = True
 
             if skip:
-                log.info('Aborted file {}'.format(infile))
-                processing_queue.remove(infile)
-                continue
+                log.info('Aborted file {}, pid {}'.format(infile, pid))
+                sys.exit(1)
 
             feed_idx = ''
             if not infile.endswith('.fits'):
@@ -206,8 +195,11 @@ class MyEventHandler(PatternMatchingEventHandler):
                         os.remove(oldfile)
 
             lock.release()
-            log.info('Completed file {}'.format(infile))
-            processing_queue.remove(infile)
+
+            log.info('Completed file {}, pid {}'.format(infile, pid))
+        except KeyboardInterrupt:
+            pass
+        sys.exit(0)
 
 
 class MyRequestHandler(SimpleHTTPRequestHandler):
@@ -304,7 +296,7 @@ def main_monitor(args=None):
         '-w', '--workers',
         type=workers_count,
         default=1,
-        help='The number of worker processes to spawn'
+        help='The maximum number of worker processes to spawn'
     )
     args = parser.parse_args(args)
 

--- a/srttools/scan.py
+++ b/srttools/scan.py
@@ -298,8 +298,8 @@ def _get_spectrum_stats(dynamical_spectrum, freqsplat, bandwidth,
 
 def clean_scan_using_variability(dynamical_spectrum, length, bandwidth,
                                  good_mask=None, freqsplat=None,
-                                 noise_threshold=5., debug=True, nofilt=False,
-                                 outfile="out", label="",
+                                 noise_threshold=5., debug=True, plot=True,
+                                 nofilt=False, outfile="out", label="",
                                  smoothing_window=0.05,
                                  debug_file_format='pdf',
                                  info_string="Empty info string"):
@@ -340,6 +340,8 @@ def clean_scan_using_variability(dynamical_spectrum, length, bandwidth,
         considered noisy
     debug : bool
         Print out debugging information
+    plot : bool
+        Plot stuff
     nofilt : bool
         Do not filter noisy channels (set noise_threshold to 1e32)
     outfile : str
@@ -377,7 +379,7 @@ def clean_scan_using_variability(dynamical_spectrum, length, bandwidth,
         bandwidth_unit = u.MHz
 
     if len(dynamical_spectrum.shape) == 1:
-        if not debug or not HAS_MPL:
+        if not plot or not HAS_MPL:
             return None
 
         lc = dynamical_spectrum
@@ -468,7 +470,7 @@ def clean_scan_using_variability(dynamical_spectrum, length, bandwidth,
     results.freqmax = freqmax * u.MHz
     results.mask = wholemask
 
-    if not debug or not HAS_MPL:
+    if not plot or not HAS_MPL:
         return results
 
     # Now, PLOT IT ALL --------------------------------
@@ -634,7 +636,7 @@ class Scan(Table):
     """Class containing a single scan."""
 
     def __init__(self, data=None, config_file=None, norefilt=True,
-                 interactive=False, nosave=False, debug=False,
+                 interactive=False, nosave=False, debug=False, plot=False,
                  freqsplat=None, nofilt=False, nosub=False, avoid_regions=None,
                  save_spectrum=False, **kwargs):
         """Load a Scan object
@@ -704,7 +706,7 @@ class Scan(Table):
                     not self.meta['backsub'])) and not nosub:
                 log.info('Subtracting the baseline')
                 self.baseline_subtract(avoid_regions=avoid_regions,
-                                       plot=debug)
+                                       plot=plot)
 
             if not nosave:
                 self.save()
@@ -731,7 +733,7 @@ class Scan(Table):
         return infostr
 
     def clean_and_splat(self, good_mask=None, freqsplat=None,
-                        noise_threshold=5, debug=True,
+                        noise_threshold=5, debug=True, plot=True,
                         save_spectrum=False, nofilt=False):
         """Clean from RFI.
 
@@ -760,12 +762,15 @@ class Scan(Table):
         save_spectrum : bool, default False
             Save the spectrum into a 'ChX_spec' column
         debug : bool, default True
+            Be verbose
+        plot : bool, default True
             Save images with quicklook information on single scans
         nofilt : bool
             Do not filter noisy channels (see
             :func:`clean_scan_using_variability`)
         """
-        log.debug("Noise threshold: {}".format(noise_threshold))
+        if debug:
+            log.debug("Noise threshold: {}".format(noise_threshold))
 
         if self.meta['filtering_factor'] > 0.5:
             warnings.warn("Don't use filtering factors > 0.5. Skipping.")
@@ -786,7 +791,7 @@ class Scan(Table):
                     good_mask=good_mask,
                     freqsplat=freqsplat,
                     noise_threshold=noise_threshold,
-                    debug=debug, nofilt=nofilt,
+                    debug=debug, plot=plot, nofilt=nofilt,
                     outfile=self.root_name(self.meta['filename']),
                     label="{}".format(ic),
                     smoothing_window=self.meta['smooth_window'],

--- a/srttools/tests/coveragerc
+++ b/srttools/tests/coveragerc
@@ -12,8 +12,6 @@ omit =
    {packagename}/*/tests/*
    {packagename}/*/*/tests/*
    {packagename}/version*
-concurrency = multiprocessing
-parallel = True
 
 [report]
 exclude_lines =

--- a/srttools/tests/coveragerc
+++ b/srttools/tests/coveragerc
@@ -12,6 +12,7 @@ omit =
    {packagename}/*/tests/*
    {packagename}/*/*/tests/*
    {packagename}/version*
+concurrency = multiprocessing
 
 [report]
 exclude_lines =

--- a/srttools/tests/coveragerc
+++ b/srttools/tests/coveragerc
@@ -13,6 +13,7 @@ omit =
    {packagename}/*/*/tests/*
    {packagename}/version*
 concurrency = multiprocessing
+parallel = True
 
 [report]
 exclude_lines =

--- a/srttools/tests/data/test_config.ini
+++ b/srttools/tests/data/test_config.ini
@@ -19,4 +19,4 @@ list_of_directories :
 pixel_size : 0.5
 
 [debugging]
-debug_file_format : jpg
+debug_file_format : png

--- a/srttools/tests/test_monitor.py
+++ b/srttools/tests/test_monitor.py
@@ -46,22 +46,22 @@ class TestMonitor(object):
                                          "srt_data_dummy.hdf5"))
         klass.file_empty_pdf0 = \
             os.path.abspath(os.path.join(klass.datadir,
-                                         "srt_data_dummy_0.jpg"))
+                                         "srt_data_dummy_0.png"))
         klass.file_empty_pdf1 = \
             os.path.abspath(os.path.join(klass.datadir,
-                                         "srt_data_dummy_1.jpg"))
+                                         "srt_data_dummy_1.png"))
         klass.file_empty_hdf5_alt = \
             os.path.abspath(os.path.join(klass.proddir,
                                          "srt_data_dummy.hdf5"))
         klass.file_empty_pdf0_alt = \
             os.path.abspath(os.path.join(klass.proddir,
-                                         "srt_data_dummy_0.jpg"))
+                                         "srt_data_dummy_0.png"))
         klass.file_empty_pdf1_alt = \
             os.path.abspath(os.path.join(klass.proddir,
-                                         "srt_data_dummy_1.jpg"))
+                                         "srt_data_dummy_1.png"))
         klass.file_empty_pdf10 = \
             os.path.abspath(os.path.join(klass.proddir,
-                                         "srt_data_dummy5_0.jpg"))
+                                         "srt_data_dummy5_0.png"))
         klass.file_empty_hdf5_SF = \
             os.path.abspath(os.path.join(klass.proddir,
                                          "srt_data_dummy5.hdf5"))
@@ -113,7 +113,7 @@ class TestMonitor(object):
         w.join()
 
         for fname in [self.file_empty_pdf0, self.file_empty_pdf1,
-                      'latest_0.jpg', 'latest_1.jpg']:
+                      'latest_0.png', 'latest_1.png']:
             assert os.path.exists(fname)
             os.unlink(fname)
 
@@ -135,7 +135,7 @@ class TestMonitor(object):
         w.join()
 
         for fname in [self.file_empty_pdf0_alt, self.file_empty_pdf1_alt,
-                      'latest_0.jpg', 'latest_1.jpg']:
+                      'latest_0.png', 'latest_1.png']:
             assert os.path.exists(fname)
             os.unlink(fname)
 
@@ -157,7 +157,7 @@ class TestMonitor(object):
         w.join()
 
         for fname in [self.file_empty_pdf0_alt, self.file_empty_pdf1_alt,
-                      'latest_0.jpg', 'latest_1.jpg']:
+                      'latest_0.png', 'latest_1.png']:
             assert os.path.exists(fname)
             os.unlink(fname)
 
@@ -179,7 +179,7 @@ class TestMonitor(object):
         w.join()
 
         for fname in [self.file_empty_pdf10, self.file_empty_hdf5_SF,
-                      'latest_10.jpg']:
+                      'latest_10.png']:
             assert os.path.exists(fname)
             os.unlink(fname)
 
@@ -199,7 +199,7 @@ class TestMonitor(object):
         w.join()
 
         for fname in [self.file_empty_pdf0, self.file_empty_pdf1,
-                      'latest_0.jpg', 'latest_1.jpg']:
+                      'latest_0.png', 'latest_1.png']:
             assert os.path.exists(fname)
             os.unlink(fname)
 
@@ -222,7 +222,7 @@ class TestMonitor(object):
                       self.file_empty_hdf5]:
             assert not os.path.exists(fname)
 
-        for fname in ['latest_0.jpg', 'latest_1.jpg']:
+        for fname in ['latest_0.png', 'latest_1.png']:
             assert os.path.exists(fname)
             os.unlink(fname)
 
@@ -254,8 +254,8 @@ class TestMonitor(object):
             self.file_empty_pdf10.replace('dummy5', 'dummy4'),
             self.file_empty_hdf5_SF,
             self.file_empty_hdf5_SF.replace('dummy5', 'dummy4'),
-            'latest_8.jpg',
-            'latest_10.jpg'
+            'latest_8.png',
+            'latest_10.png'
         ]
 
         print(files)
@@ -272,7 +272,7 @@ class TestMonitor(object):
             main_monitor([self.datadir, '--test'])
 
         files = [self.file_empty_pdf0, self.file_empty_pdf1]
-        files += ['latest_{}.jpg'.format(i) for i in range(8)]
+        files += ['latest_{}.png'.format(i) for i in range(8)]
 
         for fname in files[2:]:
             sp.check_call('touch {}'.format(fname).split())
@@ -309,9 +309,9 @@ class TestMonitor(object):
         urls = [
             '',
             'index.html',
-            'latest_0.jpg',
-            'latest_1.jpg',
-            'latest_0.jpg?%d' % int(time.time())
+            'latest_0.png',
+            'latest_1.png',
+            'latest_0.png?%d' % int(time.time())
         ]
         # Check that the files are provided by the HTTP server
         for url in urls:
@@ -322,7 +322,7 @@ class TestMonitor(object):
         w.join()
 
         for fname in [self.file_empty_pdf0, self.file_empty_pdf1,
-                      'latest_0.jpg', 'latest_1.jpg']:
+                      'latest_0.png', 'latest_1.png']:
             assert os.path.exists(fname)
             os.unlink(fname)
 
@@ -342,14 +342,14 @@ class TestMonitor(object):
 
         # Ask for non-existent files
         for i in [20, 21]:
-            url = 'http://127.0.0.1:10000/latest_{}.jpg'.format(i)
+            url = 'http://127.0.0.1:10000/latest_{}.png'.format(i)
             with pytest.raises(urllib.error.HTTPError):
                 r = urllib.request.urlopen(url)
 
         w.join()
 
         for fname in [self.file_empty_pdf0, self.file_empty_pdf1,
-                      'latest_0.jpg', 'latest_1.jpg']:
+                      'latest_0.png', 'latest_1.png']:
             assert os.path.exists(fname)
             os.unlink(fname)
 
@@ -370,7 +370,7 @@ class TestMonitor(object):
         # Create a dummy 'latest_0.txt' file.
         # The file should not be accessible since its name does not match
         # 'index.html' nor 'index.html' nor 'latest_X.EXT' pattern, with EXT
-        # equal to the configured file extension, in this case is 'jpg'
+        # equal to the configured file extension, in this case is 'png'
         forbidden_file = 'latest_0.txt'
         open(forbidden_file, 'w').close()
         url = 'http://127.0.0.1:10000/' + forbidden_file
@@ -380,7 +380,7 @@ class TestMonitor(object):
         w.join()
 
         for fname in [self.file_empty_pdf0, self.file_empty_pdf1,
-                      'latest_0.jpg', 'latest_1.jpg', forbidden_file]:
+                      'latest_0.png', 'latest_1.png', forbidden_file]:
             assert os.path.exists(fname)
             os.unlink(fname)
 


### PR DESCRIPTION
Also, added a `--plot` argument to SDTpreprocess, the `--debug` argument has been splitted in `--debug`, which basically acts as a `verbose` argument, forcing the process to print debug-related messages, and `--plot`, which forces the process to plot the processed data onto images.