### PR TITLE
Resolve calibration test failures

### DIFF
--- a/srttools/calibration.py
+++ b/srttools/calibration.py
@@ -87,7 +87,8 @@ def read_calibrator_config():
 
     Examples
     --------
-    >>> calibs = read_calibrator_config()
+    >>> calibs = read_calibrator_config() # doctest: +ELLIPSIS
+    INFO...
     >>> calibs['DummyCal']['Kind']
     'CoeffTable'
     >>> 'coeffs' in calibs['DummyCal']['CoeffTable']

--- a/srttools/calibration.py
+++ b/srttools/calibration.py
@@ -145,9 +145,14 @@ def _get_calibrator_flux(calibrator, frequency, bandwidth=1, time=0):
         return None, None
 
     conf = CALIBRATOR_CONFIG[calibrator]
+
+    print(f"Bandwidth = {bandwidth}")
+
     # find closest value among frequencies
     if conf["Kind"] == "FreqList":
         idx = (np.abs(np.array(conf["Frequencies"]) - frequency)).argmin()
+        print(idx)
+        print(conf["Fluxes"][idx], conf["Bandwidths"][idx], bandwidth)
         return conf["Fluxes"][idx] * bandwidth, \
             conf["Flux Errors"][idx] * bandwidth
     elif conf["Kind"] == "CoeffTable":
@@ -201,6 +206,7 @@ def _treat_scan(scan_path, plot=False, **kwargs):
         frequency = scan[channel].meta['frequency']
         bandwidth = scan[channel].meta['bandwidth']
         temperature = scan[channel + '-Temp']
+        print(f"{channel} {bandwidth}")
 
         y = scan[channel]
 

--- a/srttools/convert.py
+++ b/srttools/convert.py
@@ -1,5 +1,3 @@
-
-from __future__ import print_function, division
 from astropy.io import fits
 import astropy.units as u
 from astropy.time import Time

--- a/srttools/data/calibrators/DummyCal2.ini
+++ b/srttools/data/calibrators/DummyCal2.ini
@@ -8,5 +8,5 @@ freq: 6800
 ; bandwidth
 bwidth: 680
 ; measured flux in Jansky, and (possibly) errors
-flux: 1
+flux: 1.321
 eflux: 0

--- a/srttools/inspect_observations.py
+++ b/srttools/inspect_observations.py
@@ -102,14 +102,14 @@ def split_observation_table(info, max_calibrator_delay=0.4,
         start_row = grouped_table[ind[0]]
         log.info("Group {}, Backend = {}, "
                  "Receiver = {}".format(i,
-                                        standard_string(start_row["Backend"]),
-                                        standard_string(start_row["Receiver"])
+                                        start_row["Backend"],
+                                        start_row["Receiver"]
                                         ))
         s = split_by_source(grouped_table[ind[0]:ind[1]],
                             max_calibrator_delay=max_calibrator_delay,
                             max_source_delay=max_source_delay)
 
-        label = ','.join([standard_string(start_row[e])
+        label = ','.join([start_row[e]
                           for e in group_by_entries])
 
         groups[label] = s
@@ -125,13 +125,13 @@ def split_by_source(info, max_calibrator_delay=0.4, max_source_delay=0.2):
     # Find observation blocks of a given source
     retval = {}
     for s in sources:
-        if standard_string(s) in calibrators:
+        if s in calibrators:
             continue
         condition = info["Source"] == s
         filtered_table = info[condition]
         if np.any(filtered_table['is_skydip']):
             continue
-        s = standard_string(s)
+        s = s
         retval[s] = {}
 
         start_idxs = []
@@ -160,9 +160,9 @@ def split_by_source(info, max_calibrator_delay=0.4, max_source_delay=0.2):
             print("Source observations:")
             retval[s]["Obs{}".format(i)]["Src"] = []
             for c in range(cont[0], cont[1]):
-                print(standard_string(filtered_table[c]["Dir"]))
+                print(filtered_table[c]["Dir"])
                 retval[s]["Obs{}".format(i)]["Src"].append(
-                    standard_string(filtered_table[c]["Dir"]))
+                    filtered_table[c]["Dir"])
 
             print("")
             print("Calibrator observations:")
@@ -175,10 +175,10 @@ def split_by_source(info, max_calibrator_delay=0.4, max_source_delay=0.2):
             condition = condition1 & condition2
 
             for row in info[condition]:
-                if standard_string(row["Source"]) in calibrators:
-                    print(standard_string(row["Dir"]))
+                if row["Source"] in calibrators:
+                    print(row["Dir"])
                     retval[s]["Obs{}".format(i)]["Cal"].append(
-                        standard_string(row["Dir"]))
+                        row["Dir"])
 
             print("")
             print("Skydip observations:")
@@ -193,9 +193,9 @@ def split_by_source(info, max_calibrator_delay=0.4, max_source_delay=0.2):
 
             for row in info[condition]:
                 if row["is_skydip"]:
-                    print(standard_string(row["Dir"]))
+                    print(row["Dir"])
                     retval[s]["Obs{}".format(i)]["Skydip"].append(
-                        standard_string(row["Dir"]))
+                        row["Dir"])
 
             print("")
             print("---------------\n")

--- a/srttools/tests/test_calibration.py
+++ b/srttools/tests/test_calibration.py
@@ -138,7 +138,9 @@ class TestCalibration(object):
         flux_quantity = _get_flux_quantity('Jy/beam')
         good = ~np.isnan(caltable[flux_quantity + "/Counts"])
         good = good&(caltable['Chan'] == 'Feed0_LCP')
-        std = np.std(np.diff(caltable[flux_quantity + "/Counts Err"][good]))
+        assert np.count_nonzero(good) > 1
+        std = np.std(np.diff(caltable[flux_quantity + "/Counts"][good]))
+        assert std > 0
         firstidx = np.where(good)[0][0]
         caltable[flux_quantity + "/Counts"][firstidx] += std * 20000
 
@@ -297,5 +299,5 @@ class TestCalibration(object):
                                        '*_scanfit'))
             for dirname in dirs:
                 shutil.rmtree(dirname)
-        if os.path.exists(klass.calfile):
-            os.remove(klass.calfile)
+        # if os.path.exists(klass.calfile):
+        #     os.remove(klass.calfile)

--- a/srttools/tests/test_calibration.py
+++ b/srttools/tests/test_calibration.py
@@ -53,10 +53,15 @@ class TestCalibration(object):
                                          "calibrators_nocal.ini"))
 
         klass.config = read_config(klass.config_file)
-        klass.caldir = os.path.join(klass.datadir, 'sim', 'calibration')
-        klass.caldir2 = os.path.join(klass.datadir, 'sim', 'calibration2')
-        klass.caldir3 = os.path.join(klass.datadir, 'sim', 'calibration_bad')
-        klass.crossdir = os.path.join(klass.datadir, 'sim', 'crossscans')
+        klass.simdir = klass.caldir = os.path.join(klass.datadir, 'sim')
+        if os.getenv('CI') and os.path.exists(klass.simdir):
+            shutil.rmtree(klass.simdir)
+
+        klass.caldir = os.path.join(klass.simdir, 'calibration')
+        klass.caldir2 = os.path.join(klass.simdir, 'calibration2')
+        klass.caldir3 = os.path.join(klass.simdir, 'calibration_bad')
+        klass.crossdir = os.path.join(klass.simdir, 'crossscans')
+
         if not os.path.exists(klass.caldir):
             log.info('Fake calibrators: DummyCal, 1 Jy.')
             mkdir_p(klass.caldir)
@@ -87,6 +92,9 @@ class TestCalibration(object):
         caltable.update()
 
         klass.calfile = os.path.join(klass.curdir, 'test_calibration.hdf5')
+        for calfile in [klass.calfile, klass.calfile.replace('hdf5', 'csv')]:
+            if os.path.exists(calfile):
+                os.remove(calfile)
         caltable.write(klass.calfile, overwrite=True)
         caltable.write(klass.calfile.replace('hdf5', 'csv'))
 
@@ -299,5 +307,5 @@ class TestCalibration(object):
                                        '*_scanfit'))
             for dirname in dirs:
                 shutil.rmtree(dirname)
-        # if os.path.exists(klass.calfile):
-        #     os.remove(klass.calfile)
+        if os.path.exists(klass.calfile):
+            os.remove(klass.calfile)

--- a/srttools/tests/test_calibration.py
+++ b/srttools/tests/test_calibration.py
@@ -37,6 +37,10 @@ def source_scan_func(x):
     return 52 * _2d_gauss(x, 0, sigma=2.5 / 60)
 
 
+def cal2_scan_func(x):
+    return 132.1 * _2d_gauss(x, 0, sigma=2.5 / 60)
+
+
 class TestCalibration(object):
     @classmethod
     def setup_class(klass):
@@ -67,9 +71,10 @@ class TestCalibration(object):
             mkdir_p(klass.caldir)
             sim_crossscans(5, klass.caldir)
         if not os.path.exists(klass.caldir2):
-            log.info('Fake calibrators: DummyCal2, 1 Jy.')
+            log.info('Fake calibrators: DummyCal2, 1.321 Jy.')
             mkdir_p(klass.caldir2)
-            sim_crossscans(5, klass.caldir2, srcname='DummyCal2')
+            sim_crossscans(5, klass.caldir2, srcname='DummyCal2',
+                           scan_func=cal2_scan_func)
         if not os.path.exists(klass.caldir3):
             log.info('Fake calibrators: DummyCal2, wrong flux 0.52 Jy.')
             mkdir_p(klass.caldir3)
@@ -150,7 +155,9 @@ class TestCalibration(object):
         std = np.std(np.diff(caltable[flux_quantity + "/Counts"][good]))
         assert std > 0
         firstidx = np.where(good)[0][0]
-        caltable[flux_quantity + "/Counts"][firstidx] += std * 20000
+        caltable[flux_quantity + "/Counts"][firstidx] = 20000
+
+        assert caltable[flux_quantity + "/Counts"][firstidx] == 20000
 
         Jc, Jce = caltable.Jy_over_counts_rough(channel='Feed0_LCP',
                                                 map_unit='Jy/beam')


### PR DESCRIPTION
Test the possible origin of calibration mismatches in test failures

What we know:

~Somehow, the tabulated flux of the calibrators is 0.68 instead of 1. This probably means that somewhere, somehow, the bandwidth (0.68 GHz!) is not read correctly. Trying different options here~

Nope. It was a problem in the order of calibrators. The calibrator table was read in a different order and the string comparison was wrong: it assigned the flux of DummySrc to DummySrc2. They were both 1, so this did not fail locally. However, it failed on Travis where the list was read in a different order (don't ask why, we'll never know).

I realized this when I started assigning different fluxes to different calibrators...

Resolve #178 