### PR TITLE
[WIP] Implement data cubes.

### DIFF
--- a/srttools/histograms.py
+++ b/srttools/histograms.py
@@ -22,6 +22,8 @@ Therefore repeated computations are prevented.
 '''
 
 
+from .utils import njit
+
 
 import numpy as np
 from numpy import atleast_2d, asarray, zeros, ones, array, atleast_1d, arange,\
@@ -400,3 +402,134 @@ def histogram2d(x, y, bins=10, bin_range=None, normed=False, weights=None):
         bins = [xedges, yedges]
     hist, edges = histogramdd([x, y], bins, bin_range, normed, weights)
     return hist, edges[0], edges[1]
+
+
+@njit(nogil=True, parallel=False)
+def _hist2d_numba_seq_weight(H, tracks, weights, bins, ranges):
+    delta = 1 / ((ranges[:, 1] - ranges[:, 0]) / bins)
+
+    for t in range(tracks.shape[1]):
+        i = (tracks[0, t] - ranges[0, 0]) * delta[0]
+        j = (tracks[1, t] - ranges[1, 0]) * delta[1]
+        if 0 <= i < bins[0] and 0 <= j < bins[1]:
+            H[int(i), int(j)] += weights[t]
+
+    return H
+
+
+def hist2d_numba_seq_weight(x, y, weights, bins, ranges):
+    """
+    Examples
+    --------
+    >>> x = np.random.uniform(0., 1., 100)
+    >>> y = np.random.uniform(2., 3., 100)
+    >>> weight = np.random.uniform(0, 1, 100)
+    >>> H, xedges, yedges = np.histogram2d(x, y, bins=(5, 5),
+    ...                                    range=[(0., 1.), (2., 3.)],
+    ...                                    weights=weight)
+    >>> Hn = hist2d_numba_seq_weight(x, y, bins=(5, 5),
+    ...                              ranges=[[0., 1.], [2., 3.]],
+    ...                              weights=weight)
+    >>> assert np.all(H == Hn)
+    """
+    H = np.zeros((bins[0], bins[1]), dtype=np.double)
+    return _hist2d_numba_seq_weight(
+        H, np.array([x, y]), weights, np.asarray(list(bins)),
+        np.asarray(ranges))
+
+
+@njit(nogil=True, parallel=False)
+def _hist3d_numba_seq_weight(H, tracks, weights, bins, ranges):
+    delta = 1 / ((ranges[:, 1] - ranges[:, 0]) / bins)
+
+    for t in range(tracks.shape[1]):
+        i = (tracks[0, t] - ranges[0, 0]) * delta[0]
+        j = (tracks[1, t] - ranges[1, 0]) * delta[1]
+        k = (tracks[2, t] - ranges[2, 0]) * delta[2]
+        if 0 <= i < bins[0] and 0 <= j < bins[1]:
+            H[int(i), int(j), int(k)] += weights[t]
+
+    return H
+
+
+def hist3d_numba_seq_weight(tracks, weights, bins, ranges):
+    """
+    Examples
+    --------
+    >>> x = np.random.uniform(0., 1., 100)
+    >>> y = np.random.uniform(2., 3., 100)
+    >>> z = np.random.uniform(4., 5., 100)
+    >>> weights = np.random.uniform(0, 1., 100)
+    >>> H, _ = np.histogramdd((x, y, z), bins=(5, 6, 7),
+    ...                       range=[(0., 1.), (2., 3.), (4., 5)],
+    ...                       weights=weights)
+    >>> Hn = hist3d_numba_seq_weight(
+    ...    (x, y, z), weights, bins=(5, 6, 7),
+    ...    ranges=[[0., 1.], [2., 3.], [4., 5.]])
+    >>> assert np.all(H == Hn)
+    """
+
+    H = np.zeros((bins[0], bins[1], bins[2]), dtype=np.double)
+    return _hist3d_numba_seq_weight(
+        H, np.asarray(tracks), weights, np.asarray(list(bins)),
+        np.asarray(ranges))
+
+
+@njit(nogil=True, parallel=False)
+def index_arr(a, ix_arr):
+    strides = np.array(a.strides) / a.itemsize
+    ix = int((ix_arr * strides).sum())
+    return a.ravel()[ix]
+
+
+@njit(nogil=True, parallel=False)
+def index_set_arr(a, ix_arr, val):
+    strides = np.array(a.strides) / a.itemsize
+    ix = int((ix_arr * strides).sum())
+    a.ravel()[ix] = val
+
+
+@njit(nogil=True, parallel=False)
+def _histnd_numba_seq(H, tracks, bins, ranges, slice_int):
+    delta = 1 / ((ranges[:, 1] - ranges[:, 0]) / bins)
+
+    for t in range(tracks.shape[1]):
+        slicearr = np.array([(tracks[dim, t] - ranges[dim, 0]) * delta[dim]
+                             for dim in range(tracks.shape[0])])
+
+        good = np.all((slicearr < bins) & (slicearr >= 0))
+        slice_int[:] = slicearr
+
+        if good:
+            curr = index_arr(H, slice_int)
+            index_set_arr(H, slice_int, curr + 1)
+
+    return H
+
+
+def histnd_numba_seq(tracks, bins, ranges):
+    """
+    Examples
+    --------
+    >>> x = np.random.uniform(0., 1., 100)
+    >>> y = np.random.uniform(2., 3., 100)
+    >>> z = np.random.uniform(4., 5., 100)
+    >>> # 2d example
+    >>> H, _, _ = np.histogram2d(x, y, bins=np.array((5, 5)),
+    ...                          range=[(0., 1.), (2., 3.)])
+    >>> alldata = np.array([x, y])
+    >>> Hn = histnd_numba_seq(alldata, bins=np.array([5, 5]),
+    ...                       ranges=np.array([[0., 1.], [2., 3.]]))
+    >>> assert np.all(H == Hn)
+    >>> # 3d example
+    >>> H, _ = np.histogramdd((x, y, z), bins=np.array((5, 6, 7)),
+    ...                       range=[(0., 1.), (2., 3.), (4., 5)])
+    >>> alldata = np.array([x, y, z])
+    >>> Hn = hist3d_numba_seq(alldata, bins=np.array((5, 6, 7)),
+    ...                       ranges=np.array([[0., 1.], [2., 3.], [4., 5.]]))
+    >>> assert np.all(H == Hn)
+    """
+    H = np.zeros(tuple(bins), dtype=np.uint64)
+    slice_int = np.zeros(len(bins), dtype=np.uint64)
+
+    return _histnd_numba_seq(H, tracks, bins, ranges, slice_int)

--- a/srttools/utils.py
+++ b/srttools/utils.py
@@ -64,12 +64,12 @@ def _generic_dummy_decorator(*args, **kwargs):
 
 
 try:
-    from numba import jit, vectorize
+    from numba import jit, vectorize, njit
     HAS_NUMBA = True
 except ImportError:
     warnings.warn("Numba not installed. Faking it")
 
-    jit = vectorize = _generic_dummy_decorator
+    jit = vectorize = njit = _generic_dummy_decorator
     HAS_NUMBA = False
 
 


### PR DESCRIPTION
This PR aims at producing data cubes out of SDTimager. The functionality is more or less there, but we need to change the code in a few points
- [ ] We need fast histogram functions for the increased data size.
- [ ] The `histogram2d` functions in `imager.py:559--` have to be substituted by histogram3d functions, and the 2-d case has to work as a special case with a single bin along the 3rd dimension
- [ ] Calibration has to take into account this new format
- [ ] The output data format of images has to change slightly to accommodate these cubes, and revert to the 2d case for non-spectroscopic images.
- [ ] _Desideratum_: as the increased data size might fill up the memory, this might be a good moment to implement some sort of memory mapping.