### PR TITLE
Be more permissive with calibrator names

### DIFF
--- a/srttools/calibration.py
+++ b/srttools/calibration.py
@@ -223,6 +223,8 @@ def _get_calibrator_flux(calibrator, frequency, bandwidth=1, time=0):
 
     calibrators = CALIBRATOR_CONFIG.keys()
     new_calibrator_name = find_calibrator_in_list(calibrator, calibrators)
+    if new_calibrator_name is None:
+        return None, None
     conf = CALIBRATOR_CONFIG[new_calibrator_name]
 
     # find closest value among frequencies

--- a/srttools/calibration.py
+++ b/srttools/calibration.py
@@ -137,6 +137,82 @@ def read_calibrator_config():
     return configs
 
 
+def _match_calibrator_name(calibrator, calibrators, relax=False):
+    """Match a calibrator name to the ones in the config file.
+
+    Parameters
+    ----------
+    calibrator : str
+        Name of the calibrator to match.
+    calibrators : list of str
+        List of calibrators in the config file.
+
+    Returns
+    -------
+    calibrator : str
+        Name of the calibrator in the config file.
+    """
+    if relax:
+        for cal in calibrators:
+            if calibrator == cal or calibrator in cal or cal in calibrator:
+                return cal
+    else:
+        for cal in calibrators:
+            if calibrator == cal:
+                return cal
+    return None
+
+
+def find_calibrator_in_list(calibrator, calibrators):
+    """Find a calibrator in the config file.
+
+    Start by searching for the exact name, and if not present, look for
+    similar names.
+
+    Parameters
+    ----------
+    calibrator : str
+        Name of the calibrator to match.
+    calibrators : list of str
+        List of calibrators in the config file.
+
+    Returns
+    -------
+    calibrator : str
+        Name of the calibrator in the config file.
+
+    Examples
+    --------
+    >>> calibrators = ['3C48', '3C286', '3C147', '3C138', '3C295', '3C196', '3C9']
+    >>> calibrator = '3C48'
+    >>> find_calibrator_in_list(calibrator, calibrators)
+    '3C48'
+    >>> calibrator = '3C286a'
+    >>> cal = find_calibrator_in_list(calibrator, calibrators)
+    >>> cal
+    '3C286'
+    >>> calibrator = 'bla'
+    >>> cal = find_calibrator_in_list(calibrator, calibrators)
+    >>> cal is None
+    True
+    """
+
+    new_calibrator = _match_calibrator_name(calibrator, calibrators)
+
+    if new_calibrator is None:
+        logging.warning(
+            f"Calibrator {calibrator} not found with exact name in config file. Trying to relax the search."
+        )
+        new_calibrator = _match_calibrator_name(calibrator, calibrators, relax=True)
+
+        if new_calibrator is None:
+            logging.warning(f"Calibrator {calibrator} not found in config file.")
+        else:
+            logging.warning(f"Found similarly-named {new_calibrator} in config file.")
+
+    return new_calibrator
+
+
 def _get_calibrator_flux(calibrator, frequency, bandwidth=1, time=0):
     global CALIBRATOR_CONFIG
 
@@ -146,15 +222,8 @@ def _get_calibrator_flux(calibrator, frequency, bandwidth=1, time=0):
         CALIBRATOR_CONFIG = read_calibrator_config()
 
     calibrators = CALIBRATOR_CONFIG.keys()
-
-    for cal in calibrators:
-        if cal == calibrator:
-            calibrator = cal
-            break
-    else:
-        return None, None
-
-    conf = CALIBRATOR_CONFIG[calibrator]
+    new_calibrator_name = find_calibrator_in_list(calibrator, calibrators)
+    conf = CALIBRATOR_CONFIG[new_calibrator_name]
 
     # find closest value among frequencies
     if conf["Kind"] == "FreqList":

--- a/srttools/calibration.py
+++ b/srttools/calibration.py
@@ -151,6 +151,20 @@ def _match_calibrator_name(calibrator, calibrators, relax=False):
     -------
     calibrator : str
         Name of the calibrator in the config file.
+
+    Examples
+    --------
+    >>> calibrators = ['3C48', '3C286', '3C147', '3C138', '3C295', '3C196', '3C9']
+    >>> calibrator = '3C48'
+    >>> _match_calibrator_name(calibrator, calibrators)
+    '3C48'
+    >>> calibrator = '3C286a'
+    >>> cal = _match_calibrator_name(calibrator, calibrators)  # This should fail
+    >>> cal is None
+    True
+    >>> cal = _match_calibrator_name(calibrator, calibrators, relax=True)  # This should work
+    >>> cal
+    '3C286'
     """
     if relax:
         for cal in calibrators:


### PR DESCRIPTION
Resolve #222 

It turns out the dataset from the original issue had a bad name for the calibrator (NGC7027-C instead of NGC7027). 
In principle, this should never happen. Source names should be exactly correct in observations. In practice, this happens. So, I relaxed the criterion to match a calibrator to the list of known calibrators. The condition is now:
`calibrator == known_calibrator_name or calibrator in known_calibrator_name or known_calibrator_name in calibrator`

This matches NGC7027-C to NGC7027, as in the OP, but also, e.g. J1808 to SAX J1808-3654. A warning is issued in this case.

