### PR TITLE
Use rough calibration if the calibrator's elevation was too far from the source's

### DIFF
--- a/docs/changes/246.bugfix.rst
+++ b/docs/changes/246.bugfix.rst
@@ -1,0 +1,1 @@
+Use rough calibration if the calibrator's elevation was too far from the source's. This avoids a bug where a linear calibration vs elevation curve was extrapolated too far (and even gave negative values in some cases)

--- a/srttools/calibration.py
+++ b/srttools/calibration.py
@@ -820,6 +820,9 @@ class CalibratorTable(Table):
             good_mask = self["Flux"] > 0
 
         flux_quantity = _get_flux_quantity(map_unit)
+        if channel not in self["Chan"]:
+            warnings.warn("No calibration found for channel {}".format(channel))
+            return None, None
 
         if channel not in self.calibration.keys():
             self.compute_conversion_function(map_unit, good_mask=good_mask)

--- a/srttools/calibration.py
+++ b/srttools/calibration.py
@@ -1423,10 +1423,18 @@ def main_cal(args=None):
     snr = caltable["Counts"] / caltable["Data Std"]
     N = len(caltable)
     good = snr > args.snr_min
+    chans = list(set(caltable["Chan"]))
+
     caltable = caltable[good]
     logging.info(
         f"{len(caltable)} good calibrator observations found above " f"SNR={args.snr_min} (of {N})"
     )
+    for chan in chans:
+        good_chan = caltable["Chan"] == chan
+        if not np.any(good_chan):
+            warnings.warn(
+                f"No good data for channel {chan}. Try using the --snr-min option with some value lower than {args.snr_min}"
+            )
     caltable.update()
 
     if args.check:

--- a/srttools/calibration.py
+++ b/srttools/calibration.py
@@ -27,7 +27,7 @@ from .scan import Scan, list_scans
 from .read_config import read_config, sample_config_file, get_config_file
 from .fit import fit_baseline_plus_bell
 from .io import mkdir_p
-from .utils import standard_byte, TWOPI
+from .utils import standard_byte, TWOPI, info_once
 from .utils import HAS_STATSM, calculate_moments, scantype
 
 try:
@@ -104,7 +104,7 @@ def read_calibrator_config():
         cparser = configparser.ConfigParser()
         cparser.read(cfile)
 
-        logging.info(f"Reading {cfile}")
+        info_once(logging, f"Reading {cfile}")
         if "CoeffTable" not in list(cparser.sections()):
             configs[cparser.get("Info", "Name")] = {
                 "Kind": "FreqList",
@@ -230,7 +230,7 @@ def find_calibrator_in_list(calibrator, calibrators):
 def _get_calibrator_flux(calibrator, frequency, bandwidth=1, time=0):
     global CALIBRATOR_CONFIG
 
-    logging.info(f"Getting calibrator flux from {calibrator}")
+    info_once(logging, f"Getting calibrator flux from {calibrator}")
 
     if CALIBRATOR_CONFIG is None:
         CALIBRATOR_CONFIG = read_calibrator_config()

--- a/srttools/imager.py
+++ b/srttools/imager.py
@@ -703,14 +703,18 @@ class ScanSet(Table):
                     final_unit,
                 ) = self._calculate_calibration_factors(map_unit)
 
-                (
-                    Jy_over_counts,
-                    Jy_over_counts_err,
-                ) = conversion_units * caltable.Jy_over_counts(
+                fc, fce = caltable.Jy_over_counts(
                     channel=ch,
                     map_unit=map_unit,
                     elevation=self["el"][:, feed][good],
                 )
+                if fc is None:
+                    logging.error(f"Calibration is invalid for channel {ch}")
+                    counts = counts * np.nan
+                    continue
+
+                Jy_over_counts = fc * conversion_units
+                Jy_over_counts_err = fce * conversion_units
 
                 counts = counts * u.ct * area_conversion * Jy_over_counts
                 counts = counts.to(final_unit).value

--- a/srttools/utils.py
+++ b/srttools/utils.py
@@ -8,7 +8,8 @@ import time
 import warnings
 import re
 from typing import List
-
+from functools import lru_cache
+from logging import Logger
 
 from collections import OrderedDict
 from collections.abc import Iterable
@@ -146,6 +147,16 @@ else:
         if angle >= np.pi:
             angle -= TWOPI
         return angle
+
+
+@lru_cache(10)
+def warn_once(logger: Logger, msg: str):
+    logger.warning(msg)
+
+
+@lru_cache(10)
+def info_once(logger: Logger, msg: str):
+    logger.info(msg)
 
 
 def get_circular_statistics(array):


### PR DESCRIPTION
The elevation-calibration law calculated in `SDTcal` is a linear function, and it can be imprecise outside the fitted range, to the point that it could even get to negative values. 
Now, the code will through a warning when this happens, and use a rougher constant calibration which should be more robust outside the validity range.

Also here:

+ Exit cleanly if no valid calibration is present for a given channel (and suggest way to get a valid one)
+ Better logging
+ Fix for recent Numpy/Astropy/HDF5