### PR TITLE
Fix #255, enhanced the SDTmonitor web page

### DIFF
--- a/docs/changes/256.feature.rst
+++ b/docs/changes/256.feature.rst
@@ -1,0 +1,1 @@
+Enhanced quicklook webpage so that it allows the user to select the main feed to be displayed on screen

--- a/srttools/monitor/webserver.py
+++ b/srttools/monitor/webserver.py
@@ -83,6 +83,12 @@ def create_index_file(port):
     <div id="thumbnail-bar"></div>
 
     <script>
+        let destination = document.location.href;
+        if (destination.startsWith("file")) {
+            destination = "localhost";
+        } else {
+            destination = document.location.href.split(":")[1];
+        }
         const whiteImage = "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D";
         let selectedPairIndex = 0;
         let images = [];
@@ -191,7 +197,7 @@ def create_index_file(port):
         }
 
         function connect() {
-            let ws = new WebSocket("ws://localhost:"""
+            let ws = new WebSocket("ws://" + destination + ":"""
         + str(port)
         + """/images");
 

--- a/srttools/monitor/webserver.py
+++ b/srttools/monitor/webserver.py
@@ -18,7 +18,7 @@ from srttools.monitor.common import MAX_FEEDS, log
 
 def create_index_file(port):
     html_string = (
-"""<!DOCTYPE html>
+        """<!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">
@@ -149,7 +149,9 @@ def create_index_file(port):
         }
 
         function connect() {
-            let ws = new WebSocket("ws://localhost:""" + str(port) + """/images");
+            let ws = new WebSocket("ws://localhost:"""
+        + str(port)
+        + """/images");
 
             ws.onmessage = function(message) {
                 let msg = JSON.parse(message.data);
@@ -164,7 +166,8 @@ def create_index_file(port):
         connect();
     </script>
 </body>
-</html>""")
+</html>"""
+    )
     with open("index.html", "w") as fobj:
         print(html_string, file=fobj)
 


### PR DESCRIPTION
The web page now displays a bar at the bottom. The bar shows all the channels grouped by feed number (LHCP + RHCP). On top of the bar, in the top 90% of the window, a single pair of channels is displayed fully. The user can click on a feed/pair and replace the main one on the top of the screen.
For the _FEED X_ text I used the same font used by matplotlib inside the images.

Default FEED 0:
![Screenshot from 2025-03-07 21-40-20](https://github.com/user-attachments/assets/e9200835-e0d5-4686-b65d-52f7a6ac9b8d)

The user selected FEED 3:
![Screenshot from 2025-03-07 21-40-54](https://github.com/user-attachments/assets/84e07bef-f014-4bca-be4a-b80d9be21212)