### PR TITLE
Fix #262, `commonprefix` becomes `commonpath`

### DIFF
--- a/srttools/scan.py
+++ b/srttools/scan.py
@@ -61,7 +61,7 @@ def product_path_from_file_name(fname, workdir=".", productdir=None):
     if productdir is None:
         rootdir = filedir
     else:
-        base = os.path.commonprefix([filedir, workdir])
+        base = os.path.commonpath([filedir, workdir])
         relpath = os.path.relpath(filedir, base)
         rootdir = os.path.join(productdir, relpath)
 


### PR DESCRIPTION
The use of `commonprefix` can cause issues when the 2 compared directories have similar prefixes. For example:

directory 1:         /home/giuseppe/directory1
directory 2:         /home/giuseppe/directory2
commonprefix:   /home/giuseppe/directory    -> does not exist
commonpath:     /home/giuseppe                   -> correct last common directory