### PR TITLE
Fix #272, CI tests now won't stop for other errors

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -95,6 +95,7 @@ jobs:
 
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: Code style checks with black

--- a/docs/changes/273.trivial.rst
+++ b/docs/changes/273.trivial.rst
@@ -1,0 +1,4 @@
+Introduced the ``fail-fast: false`` strategy on CI tests. This will allow
+runners to go on if tests on another runner failed. This will allow to spot
+OS/Python version related issues from common issues without having to commit
+and wait another test failure on another platform.


### PR DESCRIPTION
A runner will not be stopped because tests on another runner failed. This will ease spotting OS/Python version related issues from common issues without having to commit and re-run the tests waiting for another platform to fail before spotting the bug.