### PR TITLE
Fix #253, added `basename_only` config keyword

### DIFF
--- a/docs/changes/274.feature.rst
+++ b/docs/changes/274.feature.rst
@@ -1,0 +1,4 @@
+Added the ``basename_only`` configuration keyword.
+
+The said keyword allow to write output files directly inside the desired
+productdir avoiding replicating the full original path.

--- a/srttools/monitor/monitor.py
+++ b/srttools/monitor/monitor.py
@@ -137,6 +137,7 @@ class Monitor:
             configuration = read_config(self._config_file)
         self._productdir = configuration["productdir"]
         self._workdir = configuration["workdir"]
+        self._basename_only = configuration["basename_only"]
         self._extension = configuration["debug_file_format"]
 
         # Objects needed by the file observer
@@ -269,7 +270,10 @@ class Monitor:
         # While the process executes, we retrieve
         # information regarding original and new files
         productdir, fname = product_path_from_file_name(
-            infile, productdir=self._productdir, workdir=self._workdir
+            infile,
+            productdir=self._productdir,
+            workdir=self._workdir,
+            basename_only=self._basename_only
         )
         root = os.path.join(productdir, fname.rsplit(".fits")[0])
 

--- a/srttools/monitor/monitor.py
+++ b/srttools/monitor/monitor.py
@@ -273,7 +273,7 @@ class Monitor:
             infile,
             productdir=self._productdir,
             workdir=self._workdir,
-            basename_only=self._basename_only
+            basename_only=self._basename_only,
         )
         root = os.path.join(productdir, fname.rsplit(".fits")[0])
 

--- a/srttools/monitor/monitor.py
+++ b/srttools/monitor/monitor.py
@@ -35,8 +35,7 @@ except ImportError:
 
 
 def create_dummy_config(filename="monitor_config.ini", extension="png"):
-    productdir = os.environ.get("TEMP", "") if "win" in sys.platform else "/tmp"
-    config_str = f"""[local]\nproductdir : {productdir}\n[analysis]\n[debugging]\ndebug_file_format : {extension}"""
+    config_str = f"[local]\nproductdir : .\nbasename_only : True\n[analysis]\n[debugging]\ndebug_file_format : {extension}"
     with open(filename, "w") as fobj:
         print(config_str, file=fobj)
     return filename

--- a/srttools/read_config.py
+++ b/srttools/read_config.py
@@ -32,6 +32,8 @@ workdir : .
 datadir : .
 ; the root directory of the data repository.
 productdir : None
+; if True, output files will be saved directly inside productdir the full path.
+basename_only : False
 
 [analysis]
 projection : ARC
@@ -118,6 +120,7 @@ def read_config(fname=None):
     config_output["workdir"] = os.path.abspath(os.curdir) + "/"
     config_output["datadir"] = os.path.abspath(os.curdir) + "/"
     config_output["productdir"] = None
+    config_output["basename_only"] = False
     config_output["list_of_directories"] = "*"
     config_output["calibrator_directories"] = []
     config_output["skydip_directories"] = []

--- a/srttools/scan.py
+++ b/srttools/scan.py
@@ -1362,7 +1362,7 @@ class Scan(Table):
                 fname,
                 workdir=self.meta["workdir"],
                 productdir=self.meta["productdir"],
-                basename_only=self.meta["basename_only"]
+                basename_only=self.meta["basename_only"],
             )
 
         return root_name(os.path.join(rootdir, fn))

--- a/srttools/scan.py
+++ b/srttools/scan.py
@@ -39,7 +39,7 @@ __all__ = [
 ]
 
 
-def product_path_from_file_name(fname, workdir=".", productdir=None):
+def product_path_from_file_name(fname, workdir=".", productdir=None, basename_only=False):
     """
     Examples
     --------
@@ -63,11 +63,14 @@ def product_path_from_file_name(fname, workdir=".", productdir=None):
     if productdir is None:
         rootdir = filedir
     else:
-        workdir = os.path.abspath(workdir)
         productdir = os.path.abspath(productdir)
-        base = os.path.commonpath([filedir, workdir])
-        relpath = os.path.relpath(filedir, base)
-        rootdir = os.path.join(productdir, relpath)
+        if basename_only:
+            rootdir = productdir
+        else:
+            workdir = os.path.abspath(workdir)
+            base = os.path.commonpath([filedir, workdir])
+            relpath = os.path.relpath(filedir, base)
+            rootdir = os.path.join(productdir, relpath)
 
     return os.path.normpath(rootdir), fn
 
@@ -1355,10 +1358,11 @@ class Scan(Table):
             rootdir = "."
 
         if self.meta["productdir"] is not None:
-            rootdir, fname = product_path_from_file_name(
+            rootdir, _ = product_path_from_file_name(
                 fname,
                 workdir=self.meta["workdir"],
                 productdir=self.meta["productdir"],
+                basename_only=self.meta["basename_only"]
             )
 
         return root_name(os.path.join(rootdir, fn))


### PR DESCRIPTION
The said keyword allow to write output files directly inside the desired `productdir` avoiding replicating the full original path